### PR TITLE
Fix bug of going back to the first stage.

### DIFF
--- a/stateprogressbar/src/main/java/com/kofigyan/stateprogressbar/StateProgressBar.java
+++ b/stateprogressbar/src/main/java/com/kofigyan/stateprogressbar/StateProgressBar.java
@@ -701,6 +701,10 @@ public class StateProgressBar extends View {
                 mEndCenterX = mNextCellWidth - (mCellWidth / 2);
             }
         }
+        else { // necessary to fix the animation going back to the first stage
+            mStartCenterX = 0;
+            mEndCenterX = 0;
+        }
     }
 
 


### PR DESCRIPTION
This fixes the bug of going back to the first stage after already moving to other stages. If you do that in the original code, the progress bar doesn't resets the drawing coordinates and the joining line between the first stage and the second stage won't be erased.