### PR TITLE
Add possibility to change state by passing an int instead of an Enum

### DIFF
--- a/sample/src/main/res/layout/activity_basic_four_states.xml
+++ b/sample/src/main/res/layout/activity_basic_four_states.xml
@@ -11,7 +11,7 @@
         android:id="@+id/state_progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:spb_currentStateNumber="three"
+        app:spb_currentStateNumberInt="3"
         app:spb_maxStateNumber="four" />
 
 </LinearLayout>

--- a/stateprogressbar/src/main/java/com/kofigyan/stateprogressbar/StateProgressBar.java
+++ b/stateprogressbar/src/main/java/com/kofigyan/stateprogressbar/StateProgressBar.java
@@ -173,7 +173,9 @@ public class StateProgressBar extends View {
             mCurrentStateDescriptionColor = a.getColor(R.styleable.StateProgressBar_spb_currentStateDescriptionColor, mCurrentStateDescriptionColor);
             mStateDescriptionColor = a.getColor(R.styleable.StateProgressBar_spb_stateDescriptionColor, mStateDescriptionColor);
 
-            mCurrentStateNumber = a.getInteger(R.styleable.StateProgressBar_spb_currentStateNumber, mCurrentStateNumber);
+            mCurrentStateNumber = a.getInteger(R.styleable.StateProgressBar_spb_currentStateNumber,
+                    a.getInteger(R.styleable.StateProgressBar_spb_currentStateNumberInt, mCurrentStateNumber));
+
             mMaxStateNumber = a.getInteger(R.styleable.StateProgressBar_spb_maxStateNumber, mMaxStateNumber);
 
             mStateSize = a.getDimension(R.styleable.StateProgressBar_spb_stateSize, mStateSize);
@@ -309,11 +311,18 @@ public class StateProgressBar extends View {
         return mCurrentStateDescriptionColor;
     }
 
-    public void setCurrentStateNumber(StateNumber currentStateNumber) {
-        validateStateNumber(currentStateNumber.getValue());
-        mCurrentStateNumber = currentStateNumber.getValue();
+    public void setCurrentStateNumber(int currentStateNumber) {
+        if (currentStateNumber > StateNumber.FIVE.getValue()) {
+            throw new RuntimeException("You try to access a state not authorized");
+        }
+        validateStateNumber(currentStateNumber);
+        mCurrentStateNumber = currentStateNumber;
         updateCheckAllStatesValues(mEnableAllStatesCompleted);
         invalidate();
+    }
+
+    public void setCurrentStateNumber(StateNumber currentStateNumber) {
+        setCurrentStateNumber(currentStateNumber.getValue());
     }
 
     public int getCurrentStateNumber() {

--- a/stateprogressbar/src/main/res/values/attrs.xml
+++ b/stateprogressbar/src/main/res/values/attrs.xml
@@ -36,6 +36,8 @@
         <attr name="spb_animationStartDelay" format="integer" />
 
 
+        <attr name="spb_currentStateNumberInt" format="integer" />
+
         <attr name="spb_currentStateNumber" format="enum">
             <enum name="one" value="1" />
             <enum name="two" value="2" />


### PR DESCRIPTION
Fix #17 

By the way, why restrict to only 5 state max with the enum and not just use integer everywhere and drop the enum?